### PR TITLE
Remove impl trait from parameter positions in Marshaller write methods

### DIFF
--- a/src/isa/bytecode.rs
+++ b/src/isa/bytecode.rs
@@ -163,19 +163,19 @@ pub trait BytecodeWrite<Id: SiteId> {
     }
 
     /// Write a single bit.
-    fn write_1bit(&mut self, data: impl Into<u1>) -> Result<(), Self::Error>;
+    fn write_1bit(&mut self, data: u1) -> Result<(), Self::Error>;
     /// Write two bits.
-    fn write_2bits(&mut self, data: impl Into<u2>) -> Result<(), Self::Error>;
+    fn write_2bits(&mut self, data: u2) -> Result<(), Self::Error>;
     /// Write three bits.
-    fn write_3bits(&mut self, data: impl Into<u3>) -> Result<(), Self::Error>;
+    fn write_3bits(&mut self, data: u3) -> Result<(), Self::Error>;
     /// Write four bits.
-    fn write_4bits(&mut self, data: impl Into<u4>) -> Result<(), Self::Error>;
+    fn write_4bits(&mut self, data: u4) -> Result<(), Self::Error>;
     /// Write five bits.
-    fn write_5bits(&mut self, data: impl Into<u5>) -> Result<(), Self::Error>;
+    fn write_5bits(&mut self, data: u5) -> Result<(), Self::Error>;
     /// Write six bits.
-    fn write_6bits(&mut self, data: impl Into<u6>) -> Result<(), Self::Error>;
+    fn write_6bits(&mut self, data: u6) -> Result<(), Self::Error>;
     /// Write seven bits.
-    fn write_7bits(&mut self, data: impl Into<u7>) -> Result<(), Self::Error>;
+    fn write_7bits(&mut self, data: u7) -> Result<(), Self::Error>;
 
     /// Write byte.
     fn write_byte(&mut self, data: u8) -> Result<(), Self::Error>;

--- a/src/library/marshaller.rs
+++ b/src/library/marshaller.rs
@@ -365,38 +365,38 @@ where
 {
     type Error = MarshallError;
 
-    fn write_1bit(&mut self, data: impl Into<u1>) -> Result<(), MarshallError> {
-        self.write(data.into().into_u8() as u32, u5::with(1))
+    fn write_1bit(&mut self, data: u1) -> Result<(), MarshallError> {
+        self.write(data.into_u8() as u32, u5::with(1))
             .map_err(MarshallError::from)
     }
 
-    fn write_2bits(&mut self, data: impl Into<u2>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(2))
+    fn write_2bits(&mut self, data: u2) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(2))
             .map_err(MarshallError::from)
     }
 
-    fn write_3bits(&mut self, data: impl Into<u3>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(3))
+    fn write_3bits(&mut self, data: u3) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(3))
             .map_err(MarshallError::from)
     }
 
-    fn write_4bits(&mut self, data: impl Into<u4>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(4))
+    fn write_4bits(&mut self, data: u4) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(4))
             .map_err(MarshallError::from)
     }
 
-    fn write_5bits(&mut self, data: impl Into<u5>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(5))
+    fn write_5bits(&mut self, data: u5) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(5))
             .map_err(MarshallError::from)
     }
 
-    fn write_6bits(&mut self, data: impl Into<u6>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(6))
+    fn write_6bits(&mut self, data: u6) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(6))
             .map_err(MarshallError::from)
     }
 
-    fn write_7bits(&mut self, data: impl Into<u7>) -> Result<(), MarshallError> {
-        self.write(data.into().to_u8() as u32, u5::with(7))
+    fn write_7bits(&mut self, data: u7) -> Result<(), MarshallError> {
+        self.write(data.to_u8() as u32, u5::with(7))
             .map_err(MarshallError::from)
     }
 


### PR DESCRIPTION
Warning can potentially cause breaking changes when using the BytecodeWrite trait

https://github.com/AluVM/aluvm/issues/133