### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/src/library/exec.rs
+++ b/src/library/exec.rs
@@ -258,12 +258,12 @@ impl Lib {
                 ExecStep::Call(site) => {
                     #[cfg(feature = "log")]
                     eprintln!("{d}calling{z} {m}{site}{z}");
-                    return Jump::Instr(site.into());
+                    return Jump::Instr(site);
                 }
                 ExecStep::Ret(site) => {
                     #[cfg(feature = "log")]
                     eprintln!("{d}returning to{z} {m}{site}{z}");
-                    return Jump::Next(site.into());
+                    return Jump::Next(site);
                 }
             }
         }

--- a/src/library/lib.rs
+++ b/src/library/lib.rs
@@ -134,7 +134,7 @@ impl Display for Lib {
         writeln!(f, "ISAE:  {}", self.isae_string())?;
         writeln!(f, "CODE: {:x}", self.code)?;
         writeln!(f, "DATA: {:x}", self.data)?;
-        if self.libs.len() > 0 {
+        if !self.libs.is_empty() {
             writeln!(
                 f,
                 "LIBS: {:8}",

--- a/src/library/marshaller.rs
+++ b/src/library/marshaller.rs
@@ -194,7 +194,7 @@ where
     fn write(&mut self, value: u32, bit_count: u5) -> Result<(), CodeEofError> {
         let mut cnt = bit_count.to_u8();
         let value = ((value as u64) << (self.bit_pos.to_u8())).to_le_bytes();
-        let n_bytes = (cnt + self.bit_pos.to_u8() + 7) / 8;
+        let n_bytes = (cnt + self.bit_pos.to_u8()).div_ceil(8);
         for i in 0..n_bytes {
             if self.bytecode.as_ref().len() >= u16::MAX as usize {
                 return Err(CodeEofError);


### PR DESCRIPTION

Running cargo clippy reports the following error.

```shell
warning: length comparison to zero
   --> src/library/lib.rs:137:12
    |
137 |         if self.libs.len() > 0 {
    |            ^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!self.libs.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
    = note: `#[warn(clippy::len_zero)]` on by default

warning: manually reimplementing `div_ceil`
   --> src/library/marshaller.rs:197:23
    |
197 |         let n_bytes = (cnt + self.bit_pos.to_u8() + 7) / 8;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.div_ceil()`: `(cnt + self.bit_pos.to_u8()).div_ceil(8)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_div_ceil
    = note: `#[warn(clippy::manual_div_ceil)]` on by default

warning: useless conversion to the same type: `core::util::Site<library::lib::LibId>`
   --> src/library/exec.rs:261:40
    |
261 |                     return Jump::Instr(site.into());
    |                                        ^^^^^^^^^^^ help: consider removing `.into()`: `site`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default

warning: useless conversion to the same type: `core::util::Site<library::lib::LibId>`
   --> src/library/exec.rs:266:39
    |
266 |                     return Jump::Next(site.into());
    |                                       ^^^^^^^^^^^ help: consider removing `.into()`: `site`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

warning: `aluvm` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p aluvm` to apply 4 suggestions)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.40s
```

This commit resolves the issue.

